### PR TITLE
Remove `Collections.unmodifiableCollection`

### DIFF
--- a/hfst-optimized-lookup-java/src/net/sf/hfst/UnweightedTransducer.java
+++ b/hfst-optimized-lookup-java/src/net/sf/hfst/UnweightedTransducer.java
@@ -3,13 +3,7 @@ package net.sf.hfst;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
-import java.util.Enumeration;
-import java.util.Vector;
-import java.util.Iterator;
-import java.util.Hashtable;
-import java.util.Stack;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
 
 import net.sf.hfst.Transducer;
 import net.sf.hfst.NoTokenizationException;
@@ -341,7 +335,7 @@ public class UnweightedTransducer implements Transducer
 	    }
 	inputString.add(HfstOptimizedLookup.NO_SYMBOL_NUMBER);
 	getAnalyses(0);
-	return Collections.unmodifiableCollection(displayVector);
+	return new ArrayList<String>(displayVector);
     }
 
     private Boolean pushState(FlagDiacriticOperation flag)

--- a/hfst-optimized-lookup-java/src/net/sf/hfst/WeightedTransducer.java
+++ b/hfst-optimized-lookup-java/src/net/sf/hfst/WeightedTransducer.java
@@ -4,13 +4,7 @@ import java.io.DataInputStream;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.Hashtable;
-import java.util.Stack;
-import java.util.Vector;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.*;
 
 import net.sf.hfst.Transducer;
 import net.sf.hfst.NoTokenizationException;
@@ -380,7 +374,7 @@ public class WeightedTransducer implements Transducer
 	    }
 	inputString.add(HfstOptimizedLookup.NO_SYMBOL_NUMBER);
 	getAnalyses(0);
-	return Collections.unmodifiableCollection(displayVector);
+	return new ArrayList<String>(displayVector);
     }
 
         private Boolean pushState(FlagDiacriticOperation flag)


### PR DESCRIPTION
There is no sense to use `Collections.unmodifiableCollection` for wrapping `displayVector` because it doesn't copy content of `displayVector` but just creates a kind of unmodifiable view. A new collection should be created in this case.