### PR TITLE
using `InputStream` instead of `FileInputStream` where possible

### DIFF
--- a/hfst-optimized-lookup-java/src/net/sf/hfst/TransducerHeader.java
+++ b/hfst-optimized-lookup-java/src/net/sf/hfst/TransducerHeader.java
@@ -1,7 +1,7 @@
 package net.sf.hfst;
 
 //import java.io.DataInputStream;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import net.sf.hfst.FormatException;
 
 /**
@@ -34,7 +34,7 @@ public class TransducerHeader
      * Read in the (56 bytes of) header information, which unfortunately
      * is mostly in little-endian unsigned form.
      */
-    public TransducerHeader(FileInputStream file) throws java.io.IOException, FormatException
+    public TransducerHeader(InputStream file) throws java.io.IOException, FormatException
     {
 	hfst3 = false;
 	intact = true; // could add some checks to toggle this and check outside
@@ -77,7 +77,7 @@ public class TransducerHeader
 		bytes.getUByte() == 0);
     }
 
-    public void read_hfst3_header(FileInputStream file) throws java.io.IOException, FormatException
+    public void read_hfst3_header(InputStream file) throws java.io.IOException, FormatException
     {
         // The only thing we really check is that the format begins with
         // HFST_OL. First we read the two bytes giving the header size...

--- a/hfst-optimized-lookup-java/src/net/sf/hfst/UnweightedTransducer.java
+++ b/hfst-optimized-lookup-java/src/net/sf/hfst/UnweightedTransducer.java
@@ -1,7 +1,7 @@
 package net.sf.hfst;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.*;
 
@@ -57,7 +57,7 @@ public class UnweightedTransducer implements Transducer
     {
 	private TransitionIndex[] indices;
 	
-	public IndexTable(FileInputStream filestream,
+	public IndexTable(InputStream filestream,
 			  Integer indicesCount) throws java.io.IOException
 	{
 	    ByteArray b = new ByteArray((int) indicesCount*6);
@@ -127,7 +127,7 @@ public class UnweightedTransducer implements Transducer
     {
 	private Transition[] transitions;
 
-	public TransitionTable(FileInputStream filestream,
+	public TransitionTable(InputStream filestream,
 			       Integer transitionCount) throws java.io.IOException
 	{
 	    ByteArray b = new ByteArray((int) transitionCount*8);
@@ -163,7 +163,7 @@ public class UnweightedTransducer implements Transducer
     protected int outputPointer;
     protected int inputPointer;
     
-    public UnweightedTransducer(FileInputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException
+    public UnweightedTransducer(InputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException
     {
 	header = h;
 	alphabet = a;

--- a/hfst-optimized-lookup-java/src/net/sf/hfst/WeightedTransducer.java
+++ b/hfst-optimized-lookup-java/src/net/sf/hfst/WeightedTransducer.java
@@ -1,9 +1,6 @@
 package net.sf.hfst;
 
-import java.io.DataInputStream;
-import java.io.BufferedInputStream;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.*;
 
 import net.sf.hfst.Transducer;
@@ -62,7 +59,7 @@ public class WeightedTransducer implements Transducer
     {
 	private TransitionIndex[] indices;
 	
-	public IndexTable(FileInputStream filestream,
+	public IndexTable(InputStream filestream,
 			  Integer indicesCount) throws java.io.IOException
 	{
 	    ByteArray b = new ByteArray((int) indicesCount*6);
@@ -145,7 +142,7 @@ public class WeightedTransducer implements Transducer
     {
 	private Transition[] transitions;
 
-	public TransitionTable(FileInputStream filestream,
+	public TransitionTable(InputStream filestream,
 			       Integer transitionCount) throws java.io.IOException
 	{
 	    ByteArray b = new ByteArray((int) transitionCount*12);
@@ -183,7 +180,7 @@ public class WeightedTransducer implements Transducer
     protected int inputPointer;
     protected float current_weight;
     
-    public WeightedTransducer(FileInputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException
+    public WeightedTransducer(InputStream file, TransducerHeader h, TransducerAlphabet a) throws java.io.IOException
     {
 	header = h;
 	alphabet = a;


### PR DESCRIPTION
If found it is better to use more generic `InputStream` because sometimes it could be useful not to store transducers in dedicated file, but in Java resources for example.